### PR TITLE
added from local json file to dictionary load

### DIFF
--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -79,12 +79,12 @@ def load_schemas_from_url(url, logger, schemas=None, resolvers=None):
     return schemas, resolvers
 
 
-def load_schemas_from_file(file, schemas=None, resolvers=None):
+def load_schemas_from_file(local_file, schemas=None, resolvers=None):
     if schemas is None:
         schemas = {}
     if resolvers is None:
         resolvers = {}
-    with open(file, "r") as r:
+    with open(local_file, "r") as r:
         response = json_loads_byteified(r.read())
         for key, schema in response.iteritems():
             schemas[key] = schema
@@ -139,7 +139,7 @@ class DataDictionary(object):
         definitions_paths=None,
         metaschema_path=None,
         url=None,
-        file=None
+        local_file=None
     ):
         """Creates a new dictionary instance.
 
@@ -165,17 +165,17 @@ class DataDictionary(object):
         )
 
         if not lazy:
-            self.load_data(directory=self.root_dir, url=url, file=file)
+            self.load_data(directory=self.root_dir, url=url, local_file=local_file)
 
-    def load_data(self, directory=None, url=None, file=None):
+    def load_data(self, directory=None, url=None, local_file=None):
         """Load and reslove all schemas from directory or url"""
         yamls, resolvers = load_schemas_from_dir(os.path.join(MOD_DIR, "schemas"))
-        if url is None and file is None:
+        if url is None and local_file is None:
             yamls, resolvers = load_schemas_from_dir(
                 directory, schemas=yamls, resolvers=resolvers
             )
         elif url is None:
-            yamls, resolvers = load_schemas_from_file(file, schemas=yamls, resolvers=resolvers)
+            yamls, resolvers = load_schemas_from_file(local_file, schemas=yamls, resolvers=resolvers)
         else:
             yamls, resolvers = load_schemas_from_url(
                 url, self.logger, schemas=yamls, resolvers=resolvers

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -170,11 +170,11 @@ class DataDictionary(object):
     def load_data(self, directory=None, url=None, local_file=None):
         """Load and reslove all schemas from directory or url"""
         yamls, resolvers = load_schemas_from_dir(os.path.join(MOD_DIR, "schemas"))
-        if url is None and local_file is None:
+        if url:
             yamls, resolvers = load_schemas_from_dir(
                 directory, schemas=yamls, resolvers=resolvers
             )
-        elif url is None:
+        elif file:
             yamls, resolvers = load_schemas_from_file(local_file, schemas=yamls, resolvers=resolvers)
         else:
             yamls, resolvers = load_schemas_from_url(

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -174,7 +174,7 @@ class DataDictionary(object):
             yamls, resolvers = load_schemas_from_dir(
                 directory, schemas=yamls, resolvers=resolvers
             )
-        elif file:
+        elif local_file:
             yamls, resolvers = load_schemas_from_file(local_file, schemas=yamls, resolvers=resolvers)
         else:
             yamls, resolvers = load_schemas_from_url(

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -79,6 +79,21 @@ def load_schemas_from_url(url, logger, schemas=None, resolvers=None):
     return schemas, resolvers
 
 
+def load_schemas_from_file(file, schemas=None, resolvers=None):
+    if schemas is None:
+        schemas = {}
+    if resolvers is None:
+        resolvers = {}
+    with open(file, "r") as r:
+        response = json_loads_byteified(r.read())
+        for key, schema in response.iteritems():
+            schemas[key] = schema
+            resolver = RefResolver("{}#".format(key), schema)
+            resolvers[key] = ResolverPair(resolver, schema)
+    return schemas, resolvers
+
+
+
 def dump_schemas_from_dir(directory):
     """Dump schema as a json"""
 
@@ -124,6 +139,7 @@ class DataDictionary(object):
         definitions_paths=None,
         metaschema_path=None,
         url=None,
+        file=None
     ):
         """Creates a new dictionary instance.
 
@@ -149,16 +165,17 @@ class DataDictionary(object):
         )
 
         if not lazy:
-            self.load_data(directory=self.root_dir, url=url)
+            self.load_data(directory=self.root_dir, url=url, file=file)
 
-    def load_data(self, directory=None, url=None):
+    def load_data(self, directory=None, url=None, file=None):
         """Load and reslove all schemas from directory or url"""
         yamls, resolvers = load_schemas_from_dir(os.path.join(MOD_DIR, "schemas"))
-
-        if url is None:
+        if url is None and file is None:
             yamls, resolvers = load_schemas_from_dir(
                 directory, schemas=yamls, resolvers=resolvers
             )
+        elif url is None:
+            yamls, resolvers = load_schemas_from_file(file, schemas=yamls, resolvers=resolvers)
         else:
             yamls, resolvers = load_schemas_from_url(
                 url, self.logger, schemas=yamls, resolvers=resolvers

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -171,14 +171,16 @@ class DataDictionary(object):
         """Load and reslove all schemas from directory or url"""
         yamls, resolvers = load_schemas_from_dir(os.path.join(MOD_DIR, "schemas"))
         if url:
-            yamls, resolvers = load_schemas_from_dir(
-                directory, schemas=yamls, resolvers=resolvers
-            )
-        elif local_file:
-            yamls, resolvers = load_schemas_from_file(local_file, schemas=yamls, resolvers=resolvers)
-        else:
             yamls, resolvers = load_schemas_from_url(
                 url, self.logger, schemas=yamls, resolvers=resolvers
+            )
+        elif local_file:
+            yamls, resolvers = load_schemas_from_file(
+                local_file, schemas=yamls, resolvers=resolvers
+            )
+        else:
+            yamls, resolvers = load_schemas_from_dir(
+                directory, schemas=yamls, resolvers=resolvers
             )
 
         self.settings = yamls.get(self.settings_path) or {}


### PR DESCRIPTION
Adding a feature to load a dictionary from a local json file. Previously dictionaries were only able to be loaded from a directory of YAML files, or a URL that points to a JSON file. This will be used for building dbgap dictionaries