### PR TITLE
fix: no "cdislogging" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     name="dictionaryutils",
     version=get_version(),
     packages=find_packages(),
-    install_requires=["PyYAML~=5.1", "jsonschema>=2.5.1", "requests~=2.18"],
+    install_requires=["PyYAML~=5.1", "jsonschema>=2.5.1", "requests~=2.18", "cdislogging~=1.0"],
     package_data={"dictionaryutils": ["schemas/*.yaml"]},
 )


### PR DESCRIPTION
<!---
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/)
before asking for review.
--->

### Bug Fixes
- Add `cdislogging` to `setup.py`: will fix the missing dependencies if nothing else installs this library