### PR TITLE
Fix/logger

### DIFF
--- a/dictionaryutils/dictionary.py
+++ b/dictionaryutils/dictionary.py
@@ -17,7 +17,7 @@ from cdislogging import get_logger
 from dictionaryutils import add_default_schema
 
 
-logger = get_logger(__name__)
+logger = get_logger('__name__', log_level='info')
 
 
 # Get this module as a variable so its attributes can be set later.

--- a/dictionaryutils/dictionary.py
+++ b/dictionaryutils/dictionary.py
@@ -17,7 +17,7 @@ from cdislogging import get_logger
 from dictionaryutils import add_default_schema
 
 
-logger = get_logger('__name__', log_level='info')
+logger = get_logger("__name__", log_level="info")
 
 
 # Get this module as a variable so its attributes can be set later.
@@ -64,4 +64,6 @@ try:
     add_default_schema(gdcdictionary)
     init(gdcdictionary)
 except Exception as e:
-    logger.error("Unable to initialize gdcdictionary: {}\n{}".format(e, traceback.format_exc()))
+    logger.error(
+        "Unable to initialize gdcdictionary: {}\n{}".format(e, traceback.format_exc())
+    )


### PR DESCRIPTION
<!---
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/)
before asking for review.
--->
Sets log level on parent logger (to INFO). 

Gets rid of annoying "No handlers could be found for dictionaryutils.dictionary" logger error so we can read the real errors. (So for instance, now when I use dictionaryutils with tube, it prints the saddening but more helpful "Unable to initialize gdcdictionary" error instead)

(Background: This should have been done when cdislogging was bumped to 1.0.0--the major version bump introduced the new requirement that the log level must be explicitly set on the parent logger)

- [x] Describe what this pull request does.
- [x] Make sure all tests pass.
- [x] Black the code.
- [x] Test manually.
- [x] Remove empty sections below.


### Bug Fixes
Fixes logger and gets rid of annoying "No handlers could be found" logger error so we can read the real errors

