### PR TITLE
Fix encoding (ASCII -> UTF8)

### DIFF
--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -35,6 +35,7 @@ def visit_directory(path):
 
 def load_yaml(name):
     """Return contents of yaml file as dict"""
+    print(name)
     with open(name, "r") as f:
         return yaml.safe_load(f)
 

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -35,8 +35,7 @@ def visit_directory(path):
 
 def load_yaml(name):
     """Return contents of yaml file as dict"""
-    print(name)
-    with open(name, "r") as f:
+    with open(name, "r", encoding="utf8") as f:
         return yaml.safe_load(f)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     name="dictionaryutils",
     version=get_version(),
     packages=find_packages(),
-    install_requires=["PyYAML~=5.3", "jsonschema~=3.2", "requests~=2.18", "cdislogging~=1.0"],
+    install_requires=["PyYAML~=5.1", "jsonschema~=3.2", "requests~=2.18", "cdislogging~=1.0"],
     package_data={"dictionaryutils": ["schemas/*.yaml"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     name="dictionaryutils",
     version=get_version(),
     packages=find_packages(),
-    install_requires=["PyYAML~=5.1", "jsonschema~=3.2", "requests~=2.18", "cdislogging~=1.0"],
+    install_requires=["PyYAML~=5.3", "jsonschema~=3.2", "requests~=2.18", "cdislogging~=1.0"],
     package_data={"dictionaryutils": ["schemas/*.yaml"]},
 )


### PR DESCRIPTION
The data simulator was breaking when reading some dictionary files because they are encoded in ascii

### Bug Fixes
- Always open YAML files with UTF8 encoding to avoid encoding errors
