### PR TITLE
fix: dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 python: 3.6
 before_script:
 - git clone https://github.com/uc-cdis/datadictionary && (cd datadictionary && yes | python setup.py install)
-- pip install gen3dictionary
 script:
 - ./run_tests.sh
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 python: 3.6
 before_script:
 - git clone https://github.com/uc-cdis/datadictionary && (cd datadictionary && yes | python setup.py install)
+- pip install gen3dictionary
 script:
 - ./run_tests.sh
 before_deploy:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,15 @@ fi
 pip install -r dev-requirements.txt
 # always use this version of dictionaryutils...
 pip uninstall -y dictionaryutils
-pip uninstall -y gen3dictionary
+
+# Here is a story. While updating data-simulator the new dependency was introduced there: gen3dictionary.
+# And because this new dependency installed after the setup.py for testing the dictionary is run,
+# it essentially tests gen3dictionary. :shrug:
+# Removing if and only we're under `dictionary/` folder, essentially testing other dictionary.
+if [[ -d ../.git && -d ../gdcdictionary ]]; then
+  pip uninstall -y gen3dictionary
+fi
+
 python setup.py install --force
 nosetests -s -v
 python bin/dump_schema.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,6 +13,7 @@ fi
 pip install -r dev-requirements.txt
 # always use this version of dictionaryutils...
 pip uninstall -y dictionaryutils
+pip uninstall -y gen3dictionary
 python setup.py install --force
 nosetests -s -v
 python bin/dump_schema.py


### PR DESCRIPTION
Here is a story. While updating data-simulator the new dependency was introduced there: gen3dictionary. And because this new dependency installed after the setup.py for testing the dictionary is run, it essentially tests gen3dictionary. :shrug:

### New Features


### Breaking Changes


### Bug Fixes
- Latest issue with dictionary Travis testing

### Improvements


### Dependency updates


### Deployment changes

