### PR TITLE
feat/format_upgrade: handle multiple $refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 dist: xenial
 python: 3.6
 before_script:
-- git clone https://github.com/uc-cdis/datadictionary && (cd datadictionary && yes | python setup.py install)
-- git checkout feat/format_upgrade 
+- git clone https://github.com/uc-cdis/datadictionary; cd datadictionary
+- git checkout feat/format_upgrade
+- yes | python setup.py install
 
 script:
 - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 3.6
 before_script:
 - git clone https://github.com/uc-cdis/datadictionary; cd datadictionary
 - git checkout feat/format_upgrade
-- yes | python setup.py install
+- yes | python setup.py install; cd ..
 
 script:
 - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: xenial
 python: 3.6
 before_script:
 - git clone https://github.com/uc-cdis/datadictionary && (cd datadictionary && yes | python setup.py install)
+- git checkout feat/format_upgrade 
+
 script:
 - ./run_tests.sh
 before_deploy:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,7 @@ rstr==2.2.6
 cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@1.4.0#egg=cdisutils
 psqlgraph==3.0.0
--e git+https://git@github.com/uc-cdis/data-simulator.git@1.2.0#egg=datasimulator
+# for testing purpose
+# -e git+https://git@github.com/uc-cdis/data-simulator.git@1.2.0#egg=datasimulator
+-e git+https://git@github.com/uc-cdis/data-simulator.git@feat/format_upgrade#egg=datasimulator
 gen3datamodel==3.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ rstr==2.2.6
 cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@1.4.0#egg=cdisutils
 psqlgraph==3.0.0
+
 # for testing purpose
 # -e git+https://git@github.com/uc-cdis/data-simulator.git@1.2.0#egg=datasimulator
 -e git+https://git@github.com/uc-cdis/data-simulator.git@feat/format_upgrade#egg=datasimulator

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ rstr==2.2.6
 cdislogging
 -e git+https://git@github.com/NCI-GDC/cdisutils.git@1.4.0#egg=cdisutils
 psqlgraph==3.0.0
-
 # for testing purpose
 # -e git+https://git@github.com/uc-cdis/data-simulator.git@1.2.0#egg=datasimulator
 -e git+https://git@github.com/uc-cdis/data-simulator.git@feat/format_upgrade#egg=datasimulator

--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -216,6 +216,14 @@ class DataDictionary(object):
 
         return resolution
 
+    def resolve_local_refs(self, refs, obj, root):
+        """Converts a string ref to list of refs & resolves the references
+        """
+        if not isinstance(refs, list):
+            refs = [refs]
+        for ref in refs:
+            obj.update(self.resolve_reference(ref, root))
+    
     def resolve_schema(self, obj, root):
         """Recursively resolves all references in a schema against
         ``self.resolvers``.
@@ -232,8 +240,8 @@ class DataDictionary(object):
         if isinstance(obj, dict):
             all_refkeys = [k for k in obj.keys() if k.startswith(refkey)]
             for key in all_refkeys:
-                val = obj.pop(key)
-                obj.update(self.resolve_reference(val, root))
+                refs = obj.pop(key)
+                self.resolve_local_refs(refs, obj, root)
             return {k: self.resolve_schema(v, root) for k, v in obj.items()}
         elif isinstance(obj, list):
             return [self.resolve_schema(item, root) for item in obj]
@@ -243,7 +251,7 @@ class DataDictionary(object):
     def allow_nulls(self):
         """
         Adds "none" to the types of non required fields in the dictionary.
-        This is done so we can remove properties from entities by updating the property to null. 
+        This is done so we can remove properties from entities by updating the property to null.
         """
         for node_properties in self.schema.values():
             required = node_properties.get("required", [])

--- a/dictionaryutils/schemas/data_release.yaml
+++ b/dictionaryutils/schemas/data_release.yaml
@@ -40,7 +40,7 @@ properties:
   type:
     enum: [ "data_release" ]
   id:
-    $ref: "_definitions.yaml#/UUID"
+    $ref: "_definitions.yaml#/uuid"
     systemAlias: node_id
   created_datetime:
     $ref: "_definitions.yaml#/datetime"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "requests~=2.18",
         "cdislogging~=1.0",
         # for testing purpose
-        "datasimulator",
+        "data-simulator",
     ],
     dependency_links=[
         # for testing purpose

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@ setup(
         "jsonschema~=3.2",
         "requests~=2.18",
         "cdislogging~=1.0",
+        # for testing purpose
+        "datasimulator","
+    ],
+    dependency_links=[
+        # for testing purpose
+        "git+https://github.com/uc-cdis/data-simulator.git@feat/format_upgrade#egg=datasimulator"
     ],
     package_data={"dictionaryutils": ["schemas/*.yaml"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "requests~=2.18",
         "cdislogging~=1.0",
         # for testing purpose
-        "datasimulator","
+        "datasimulator",
     ],
     dependency_links=[
         # for testing purpose


### PR DESCRIPTION
Added support for parsing multiple refs (list) instead of single ref. this is due to format changes made & standardized  across gen3 dictionaries.

Please dont merge the changes into master yet. it cant not be used until all the gen3 dictionaries are migrated  to new format