### PR TITLE
PXP-10952 Fix `allow_nulls()` for `oneOf/anyOf`

### DIFF
--- a/dictionaryutils/__init__.py
+++ b/dictionaryutils/__init__.py
@@ -278,7 +278,7 @@ class DataDictionary(object):
                     if not isinstance(prop["enum"], list):
                         prop["enum"] = [prop["enum"]]
                     prop["enum"].append(None)
-                elif "anyOf" in prop:
+                elif "anyOf" in prop and {"type": "null"} not in prop["anyOf"]:
                     prop["anyOf"].append({"type": "null"})
-                elif "oneOf" in prop:
+                elif "oneOf" in prop and {"type": "null"} not in prop["oneOf"]:
                     prop["oneOf"].append({"type": "null"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dictionaryutils"
-version = "3.4.5"
+version = "3.4.6"
 description = "Python wrapper and metaschema for datadictionary."
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Jira Ticket: [PXP-10952](https://ctds-planx.atlassian.net/browse/PXP-10952)

address this error when submitting a null value:
```
Validation error while validating entity […]
{'datetime': None, […] }
None is valid under each of {'type': 'null'}, {'type': 'null'}
```
for this dictionary prop:
```
datetime:
  oneOf:
    - type: string
      format: date-time
    - type: 'null'
```

### Improvements
- Fix `allow_nulls()` for `oneOf/anyOf`: do not allow "null" twice


[PXP-10952]: https://ctds-planx.atlassian.net/browse/PXP-10952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ