### PR TITLE
Revert the uninstall of gen3dictionary

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,14 +14,6 @@ pip install poetry
 which poetry
 poetry install -v
 
-# Here is a story. While updating data-simulator the new dependency was introduced there: gen3dictionary.
-# And because this new dependency installed after the setup.py for testing the dictionary is run,
-# it essentially tests gen3dictionary. :shrug:
-# Removing if and only we're under `dictionary/` folder, essentially testing other dictionary.
-if [[ -d ../.git && -d ../gdcdictionary ]]; then
-  pip uninstall -y gen3dictionary
-fi
-
 pytest tests -s -v
 python bin/dump_schema.py
 set +e


### PR DESCRIPTION
Tag 3.4.11 of `dictionaryutils` is causing an import failure for `SCHEMA_DIR` from `gdcdictionary` in the `run_tests.sh` script called by the [dictionary build script](https://github.com/uc-cdis/.github/blob/master/.github/workflows/dictionary_push.yaml).

This appears to be related to the uninstall of `gen3dictionary` in the script. The `uninstall` might not be needed any longer because of the way that the `gen3dictionary` and `gdcdictionary` are installed (ie, not over-writing).


### New Features

### Breaking Changes

### Bug Fixes
* Revert the uninstall of gen3dictionary in the test script.

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
