### PR TITLE
Skip poetry installs in test, recover uninstall of gen3dictionary

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,9 +10,13 @@ if [[ -d ../.git && -d ../gdcdictionary ]]; then
   )
 fi
 
-pip install poetry
-which poetry
-poetry install -v
+# Here is a story. While updating data-simulator the new dependency was introduced there: gen3dictionary.
+# And because this new dependency installed after the setup.py for testing the dictionary is run,
+# it essentially tests gen3dictionary. :shrug:
+# Removing if and only we're under `dictionary/` folder, essentially testing other dictionary.
+if [[ -d ../.git && -d ../gdcdictionary ]]; then
+  pip uninstall -y gen3dictionary
+fi
 
 pytest tests -s -v
 python bin/dump_schema.py


### PR DESCRIPTION
Dictionaryutils has a dependency change causing install conflicts with `gdcdictionary`. The `poetry install` commands are removed from the `run_tests.sh` script so that the dictionary push workflow has access to the correct `SCHEMA_DIR`.


### New Features

### Breaking Changes

### Bug Fixes
* Remove `poetry installs` from `run_tests.sh`.

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
